### PR TITLE
Fix 5etools docker image version number

### DIFF
--- a/msrewardsfarmer/README.md
+++ b/msrewardsfarmer/README.md
@@ -51,7 +51,14 @@ mode: single
 # Sending a notification.
 1. edit /addon-configs/2effc9b9_msrewardsfarmer/config.yaml
 1. Configure the line for a notification
-1. To send a hassio notification, use this: `https://github.com/caronc/apprise/wiki/Notify_homeassistant`
+
+It should look something like this for homeassistant notification:
+```
+# config.yaml
+apprise:
+  urls:
+    - 'hassio://192.168.X.XX/eyXXXXXXXXXXXXXXXX.eyXXXXXXXXXXXXXXXXXxx'
+```
 
 
 [repository]: https://github.com/jdeath/homeassistant-addons

--- a/msrewardsfarmer/README.md
+++ b/msrewardsfarmer/README.md
@@ -60,5 +60,6 @@ apprise:
     - 'hassio://192.168.X.XX/eyXXXXXXXXXXXXXXXX.eyXXXXXXXXXXXXXXXXXxx'
 ```
 
+More details here: `https://github.com/caronc/apprise/wiki/Notify_homeassistant`
 
 [repository]: https://github.com/jdeath/homeassistant-addons


### PR DESCRIPTION
remove "v" from version number as the upstream version number does not use this, and so the version cannot be found