### PR TITLE
Add ingress accessible to all users for PairDrop

### DIFF
--- a/PairDrop/config.json
+++ b/PairDrop/config.json
@@ -33,5 +33,7 @@
   "url": "https://github.com/jdeath/homeassistant-addons",
   "webui": "[PROTO:ssl]://[HOST]:[PORT:3000]",
   "ingress": true,
-  "ingress_port": 3000
+  "ingress_port": 3000,
+  "panel_admin": false,
+  "panel_icon": "mdi:parachute"
 }


### PR DESCRIPTION
Set the `panel_admin` parameter to `false` to allow all users to access PairDrop. I've also added the `mdi:parachute` icon