### PR TITLE
Allow setting the save location for the silverbullet docs

### DIFF
--- a/silverbullet/config.json
+++ b/silverbullet/config.json
@@ -11,7 +11,8 @@
     "PGID": "0"
   },
   "map": [
-    "addon_config:rw"
+    "addon_config:rw",
+    "share:rw"
   ],
   "version": "2.1.9",
   "name": "silverbullet",
@@ -22,10 +23,12 @@
     "3000/tcp": "Web interface"
   },
   "options": {
-    "SB_USER": ""
+    "SB_USER": "",
+    "SB_FOLDER": ""
   },
   "schema": {
-    "SB_USER": "str?"
+    "SB_USER": "str?",
+    "SB_FOLDER": "str?"
   },
   "slug": "silverbullet",
   "startup": "services",

--- a/silverbullet/run.sh
+++ b/silverbullet/run.sh
@@ -4,6 +4,7 @@ set -e
 CONFIG_PATH=/data/options.json
 cat /data/options.json
 
+# Username and password for SilverBullet user
 SB_USER=$(jq --raw-output '.SB_USER' $CONFIG_PATH)
 echo "SB_USER: ${SB_USER}"
 
@@ -13,6 +14,19 @@ else
 	echo "Setting UserName:Password"
 	echo "SB_USER: ${SB_USER}"
 	export SB_USER="${SB_USER}"
+fi
+
+# Save location for SilverBullet data
+SB_FOLDER=$(jq --raw-output '.SB_FOLDER' $CONFIG_PATH)
+echo "SB_FOLDER: ${SB_FOLDER}"
+
+if [[ -z $SB_FOLDER ]]; then 
+	echo "using default SB data folder"
+else
+	echo "Setting SB data folder"
+	echo "SB_FOLDER: ${SB_FOLDER}"
+	export SB_FOLDER="${SB_FOLDER}"
+	mkdir -p ${SB_FOLDER}
 fi
 
 /docker-entrypoint.sh


### PR DESCRIPTION
allow [configuring](https://silverbullet.md/Install/Configuration) the silverbullet storage directory, so that users can save their docs to network storage mounted in "share", or alternative locations.