### PR TITLE
Commafeed: Change application script execution to commafeed

### DIFF
--- a/commafeed/run.sh
+++ b/commafeed/run.sh
@@ -19,6 +19,6 @@ if [[ "$USE_ENV_FILE" = "true" ]]; then
 fi
 
 cd /commafeed/
-./application
+./commafeed
 
 


### PR DESCRIPTION
CommaFeed 5.12.0  changed the executable name to `commafeed`: https://github.com/Athou/commafeed/releases/tag/5.12.0

Fixes #76 